### PR TITLE
Fixed off by 32 bug on ImageDataDirectory parsing. Added test.

### DIFF
--- a/src/org/boris/pecoff4j/io/ByteArrayDataReader.java
+++ b/src/org/boris/pecoff4j/io/ByteArrayDataReader.java
@@ -34,6 +34,8 @@ public class ByteArrayDataReader implements IDataReader {
   }
 
   public int getPosition() {
+    if(position >= data.length)
+      return -1;
     return position;
   }
 

--- a/src/org/boris/pecoff4j/io/PEParser.java
+++ b/src/org/boris/pecoff4j/io/PEParser.java
@@ -462,6 +462,7 @@ public class PEParser {
         int dad = idd.getVirtualAddress();
         if (dad >= vad && dad < vex) {
           int off = dad - vad;
+          off += 32;
           IDataReader idr = new ByteArrayDataReader(b, off, idd.getSize());
           DataEntry de = new DataEntry(i, 0);
           de.baseAddress = sh.getVirtualAddress();
@@ -544,19 +545,19 @@ public class PEParser {
 
   @Nullable
   public static ImportDirectoryEntry readImportDirectoryEntry(@NotNull IDataReader dr) throws IOException {
-    ImportDirectoryEntry id = new ImportDirectoryEntry();
-    id.setImportLookupTableRVA(dr.readDoubleWord());
-    id.setTimeDateStamp(dr.readDoubleWord());
-    id.setForwarderChain(dr.readDoubleWord());
-    id.setNameRVA(dr.readDoubleWord());
-    id.setImportAddressTableRVA(dr.readDoubleWord());
+    ImportDirectoryEntry ide = new ImportDirectoryEntry();
+    ide.setImportLookupTableRVA(dr.readDoubleWord());
+    ide.setTimeDateStamp(dr.readDoubleWord());
+    ide.setForwarderChain(dr.readDoubleWord());
+    ide.setNameRVA(dr.readDoubleWord());
+    ide.setImportAddressTableRVA(dr.readDoubleWord());
 
     // The last entry is null
-    if (id.getImportLookupTableRVA() == 0) {
+    if (ide.getImportLookupTableRVA() == 0) {
       return null;
     }
 
-    return id;
+    return ide;
   }
 
   @NotNull

--- a/test/org/boris/pecoff4j/TestImportTable.java
+++ b/test/org/boris/pecoff4j/TestImportTable.java
@@ -1,0 +1,43 @@
+package org.boris.pecoff4j;
+
+import org.boris.pecoff4j.io.PEParser;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.util.Arrays;
+
+// author douggard
+
+public class TestImportTable {
+  public static void main(String[] args) throws Exception {
+    File file = new File("/tmp/bc9ab25f23827689fded588e1cadefc923e32a33a5c759c7c6b94fc7915bb6e1");
+    PE pe = PEParser.parse(file);
+    RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r");
+    ImageData imageData = pe.getImageData();
+    ImportDirectory importTable = imageData.getImportTable();
+    SectionTable sectionTable = pe.getSectionTable();
+    RVAConverter rvaConverter = sectionTable.getRVAConverter();
+
+    for (int i = 0; i < importTable.size(); ++i) {
+      ImportDirectoryEntry entry = importTable.getEntry(i);
+      int nameRVA = entry.getNameRVA();
+      int nameOffset = rvaConverter.convertVirtualAddressToRawDataPointer(nameRVA);
+      randomAccessFile.seek(nameOffset);
+      String libName = readString(randomAccessFile);
+      System.out.println(libName);
+    }
+  }
+
+  public static String readString(RandomAccessFile randomAccessFile) throws Exception {
+    byte[] byteString = new byte[512];
+    int count = 0;
+
+    while(count < 512 && (byteString[count] = (byte)randomAccessFile.read()) != 0) {
+      count += 1;
+    }
+
+    byteString = Arrays.copyOf(byteString, count);
+
+    return new String(byteString);
+  }
+}

--- a/test/org/boris/pecoff4j/TestResourceParsing.java
+++ b/test/org/boris/pecoff4j/TestResourceParsing.java
@@ -1,0 +1,51 @@
+package org.boris.pecoff4j;
+
+import org.boris.pecoff4j.io.PEParser;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.util.Arrays;
+
+// author douggard
+
+public class TestResourceParsing {
+  public static void main(String[] args) throws Exception {
+    File file = new File("/tmp/test_pe_01.exe"); //sha256 bc9ab25f23827689fded588e1cadefc923e32a33a5c759c7c6b94fc7915bb6e1
+    PE pe = PEParser.parse(file);
+    ResourceDirectory resourceTable = pe.getImageData().getResourceTable();
+    System.out.println("DIRECTORY");
+    for(int i = 0; i < resourceTable.size(); ++i) {
+      ResourceEntry resourceEntry = resourceTable.get(i);
+      System.out.println("\tENTRY");
+      traverseResources(resourceEntry.getDirectory(), 2);
+    }
+  }
+
+  // doesn't even try to handle directory structure loops
+  public static void traverseResources(ResourceDirectory directory, int depth) {
+    if(directory == null) {
+      for(int i=0; i<depth; ++i) {
+        System.out.print("\t");
+      }
+      System.out.println("DATA");
+      return;
+    }
+
+    for(int i=0; i<depth; ++i) {
+      System.out.print("\t");
+    }
+    System.out.println("DIRECTORY");
+
+//    System.out.println("||");
+    depth++;
+    for(int i=0; i<directory.size(); ++i) {
+      ResourceEntry entry = directory.get(i);
+      for(int j=0; j<depth; ++j) {
+        System.out.print("\t");
+      }
+      System.out.println("ENTRY_" + Integer.toHexString(entry.getId()));
+
+      traverseResources(entry.getDirectory(), depth+1);
+    }
+  }
+}


### PR DESCRIPTION
Changed one variable name id to ide. There are still two id variables in that file for ImageData and ImportDirectory. 

The 32 bytes are probably the section header size minus the name. The address retrieved (vad) must be pointing at the end of the section header because this fix is equivalent to doing vad -= 32. I would have done the fix by adjusting vad, however, the getVirtualSize that is used to calculate vex may also be size from the end of header. So in order to not break the range check, the adjustment is done after.

The test walks the imported library names and prints them. Output is:

```
KERNEL32.dll
USER32.dll
COMCTL32.dll
MSVCRT.dll
```

The test file used is named the sha256 for easy lookup, but it is some copy of Eclipse 4.4.
